### PR TITLE
Update tip #22 'Overriding self with a weak reference' to Swift 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1919,6 +1919,21 @@ To stop the playground from executing, simply call `PlaygroundPage.current.finis
 
 💦 Avoid memory leaks when accidentially refering to `self` in closures by overriding it locally with a weak reference:
 
+**Swift >= 4.2**
+
+```swift
+dataLoader.loadData(from: url) { [weak self] result in
+    guard let self = self else { return }
+
+    self.cache(result)
+    
+    ...
+```
+
+Accepted [proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md) now implemented in Swift 4.2
+
+**Swift < 4.2**
+
 ```swift
 dataLoader.loadData(from: url) { [weak self] result in
     guard let `self` = self else {

--- a/README.md
+++ b/README.md
@@ -1923,14 +1923,14 @@ To stop the playground from executing, simply call `PlaygroundPage.current.finis
 
 ```swift
 dataLoader.loadData(from: url) { [weak self] result in
-    guard let self = self else { return }
+    guard let self = self else { 
+        return 
+    }
 
     self.cache(result)
     
     ...
 ```
-
-Accepted [proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md) now implemented in Swift 4.2
 
 **Swift < 4.2**
 


### PR DESCRIPTION
Using optional binding to upgrade self from a weak to strong reference. Now available in Swift 4.2